### PR TITLE
feat: Define core state structures

### DIFF
--- a/programs/nestfolio/src/states/member.rs
+++ b/programs/nestfolio/src/states/member.rs
@@ -1,0 +1,10 @@
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Member {
+    pub address: Pubkey,
+    pub reputation: Vec<Pubkey>,
+    pub staked_amount: u64,
+    pub voting_power: u32,
+    pub joined_at: i64,
+}

--- a/programs/nestfolio/src/states/mod.rs
+++ b/programs/nestfolio/src/states/mod.rs
@@ -1,0 +1,7 @@
+pub mod org;
+pub mod member;
+pub mod proposal;
+
+pub use org::*;
+pub use member::*;
+pub use proposal::*;

--- a/programs/nestfolio/src/states/org.rs
+++ b/programs/nestfolio/src/states/org.rs
@@ -1,0 +1,14 @@
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Organisation {
+    pub name: String,
+    pub treasury_balance: u64,
+    pub total_members: u32,
+    pub created_at: i64,
+    pub status: bool,
+    pub proposal_limit: u32,
+    pub member_registration_fee: u64,
+    pub minimum_deposit_amount: u64,
+    pub org_bump: u8,
+}

--- a/programs/nestfolio/src/states/proposal.rs
+++ b/programs/nestfolio/src/states/proposal.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Proposal {
+    pub title: String,
+    pub description: String,
+    pub proposer: Pubkey,
+    pub up_votes: u32,
+    pub down_votes: u32,
+    pub status: ProposalStatus,
+    pub expiry_time: i64,
+    pub organization: Pubkey,
+    pub proposal_bump: u8,
+}
+#[derive(Clone, AnchorSerialize, AnchorDeserialize)]
+pub enum ProposalStatus {
+    Pending,
+    Approved,
+    Rejected,
+}


### PR DESCRIPTION
- Added `org.rs` for organization-related state management.
- Implemented `proposal.rs` to track DAO proposals.
- Created `member.rs` to manage DAO members and their voting power.
- Updated `mod.rs` to export the newly created state modules.